### PR TITLE
Feature/command line args

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,9 +30,9 @@ $> sudo apt install make
 ```bash
 $> make
 ```
-- Run app with the number of processes (e.g. np=2)
+- Run app with the number of processes and the '10^n' input (e.g. n=3 np=2)
 ```bash
-$> make np=number_of_processes run
+$> make n=power_of_10 np=number_of_processes run
 ```
 
 ## How to clean the build files

--- a/main.c
+++ b/main.c
@@ -16,7 +16,9 @@ int main (int argc, char* argv[]) {
     int src_rank;
     int number_of_processes;
     int msg_tag;
-    int n = 100000000;
+   
+    int n = atoi(argv[1]);
+    int number_of_points = pow(10, n);
 
     double buffer = 0;
     double pi = 0;
@@ -54,7 +56,7 @@ int main (int argc, char* argv[]) {
     } 
     else { //clients
         msg_tag = 0;
-        pi = monte_carlo_pi(n);
+        pi = monte_carlo_pi(number_of_points);
         MPI_Send(&pi, 1, MPI_DOUBLE, SERVER_RANK, msg_tag, MPI_COMM_WORLD);
     }
         

--- a/main.c
+++ b/main.c
@@ -8,6 +8,10 @@
 
 #define SERVER_RANK 0
 
+// User input range [3, 10]
+#define USER_INPUT_MIN 3
+#define USER_INPUT_MAX 10
+
 int main (int argc, char* argv[]) {
 
     MPI_Status status;
@@ -18,6 +22,11 @@ int main (int argc, char* argv[]) {
     int msg_tag;
    
     int n = atoi(argv[1]);
+    
+    if(n < USER_INPUT_MIN || n > USER_INPUT_MAX) {
+        n = USER_INPUT_MIN;
+    }
+
     int number_of_points = pow(10, n);
 
     double buffer = 0;

--- a/makefile
+++ b/makefile
@@ -33,7 +33,7 @@ $(MPI_BIN): $(OBJ) $(BIN) $(OBJS) $(LIBS)
 	$(CC) $(OBJS) main.c $(CFLAGS) -o $(MPI_BIN)
 
 run: 
-	mpirun --oversubscribe -np $(np) $(MPI_BIN)  
+	mpirun --oversubscribe $(MPI_BIN) $(n) -np $(np) 
 
 $(OBJ):
 	$(MKDIR) $@


### PR DESCRIPTION
### This feature takes user input via command line arguments removing the need to use a scanf function.

### Usage:
`
make n=power_of_10 np=number_of_processors run
`